### PR TITLE
Update deepseek module compiler plugin to support generate API calls when the deepseek import is not present in the file

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ icon="icon.png"
 name = "ai.deepseek"
 org = "ballerinax"
 repository = "https://github.com/ballerina-platform/module-ballerinax-ai.deepseek"
-version = "1.0.2"
+version = "1.0.3"
 
 [platform.java21]
 graalvmCompatible = true
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ai.deepseek-native"
-version = "1.0.2"
-path = "../native/build/libs/ai.deepseek-native-1.0.2.jar"
+version = "1.0.3"
+path = "../native/build/libs/ai.deepseek-native-1.0.3-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "ai-deepseek-compiler-plugin"
 class = "io.ballerina.lib.ai.deepseek.AiDeepseekCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ai.deepseek-compiler-plugin-1.0.2.jar"
+path = "../compiler-plugin/build/libs/ai.deepseek-compiler-plugin-1.0.3-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "ai"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -388,7 +388,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "ai.deepseek"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "http"},

--- a/ballerina/tests/test-generate-method-usage-in-file-without-ai-import.bal
+++ b/ballerina/tests/test-generate-method-usage-in-file-without-ai-import.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org).
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@test:Config
+function testGenerateMethodUsageInFileWithoutAiImport() returns error? {
+    Review|error result = deepseekProvider->generate(`Please rate this blog out of ${"10"}.
+        Title: ${blog2.title}
+        Content: ${blog2.content}`);
+    test:assertEquals(result, reviewRecord);
+}

--- a/ballerina/tests/test_values.bal
+++ b/ballerina/tests/test_values.bal
@@ -44,6 +44,10 @@ const blog2 = {
 
 const review = "{\"rating\": 8, \"comment\": \"Talks about essential aspects of sports performance " +
         "including warm-up, form, equipment, and nutrition.\"}";
+const reviewRecord = {
+    rating: 8,
+    comment: "Talks about essential aspects of sports performance including warm-up, form, equipment, and nutrition."
+};
 
 final string expectedPromptStringForRateBlog = string `Rate this blog out of 10.
         Title: ${blog1.title}


### PR DESCRIPTION
Update ollama module compiler plugin to support generate API calls when the ollama import is not present in the file

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8126